### PR TITLE
Fix a bug of embedLyric and add a function to adjust lyric delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Each panel has it's own additional keybinding. To view the available keybinding 
 | z               |                     toggle loop |
 | s               |                         shuffle |
 | /               |                   find in queue |
+| t               |   lyric delay increase 1 second |
+| r               |   lyric delay decrease 1 second |
 
 ### Scripting
 

--- a/command.go
+++ b/command.go
@@ -404,6 +404,20 @@ func (c Command) defineCommands() {
 		}
 	})
 
+	c.define("lyric_delay_increase", func() {
+		err := gomu.playingBar.delayLyric(1000)
+		if err != nil {
+			logError(err)
+		}
+	})
+
+	c.define("lyric_delay_decrease", func() {
+		err := gomu.playingBar.delayLyric(-1000)
+		if err != nil {
+			logError(err)
+		}
+	})
+
 	for name, cmd := range c.commands {
 		err := gomu.anko.Define(name, cmd)
 		if err != nil {

--- a/queue.go
+++ b/queue.go
@@ -330,6 +330,8 @@ func (q *Queue) help() []string {
 		"z      toggle loop",
 		"s      shuffle",
 		"/      find in queue",
+		"t      lyric delay increase 1 second",
+		"r      lyric delay decrease 1 second",
 	}
 
 }
@@ -390,6 +392,8 @@ func newQueue() *Queue {
 			'z': "toggle_loop",
 			's': "shuffle_queue",
 			'/': "queue_search",
+			't': "lyric_delay_increase",
+			'r': "lyric_delay_decrease",
 		}
 
 		for key, cmd := range cmds {

--- a/utils.go
+++ b/utils.go
@@ -249,7 +249,19 @@ func embedLyric(songPath string, lyricContent string, usltContentDescriptor stri
 		return tracerr.Wrap(err)
 	}
 	defer tag.Close()
-
+	usltFrames := tag.GetFrames(tag.CommonID("Unsynchronised lyrics/text transcription"))
+	tag.DeleteFrames(tag.CommonID("Unsynchronised lyrics/text transcription"))
+	// We delete the lyric frame with same language by delete all and add others back
+	for _, f := range usltFrames {
+		uslf, ok := f.(id3v2.UnsynchronisedLyricsFrame)
+		if !ok {
+			die(errors.New("USLT error!"))
+		}
+		if uslf.ContentDescriptor == usltContentDescriptor {
+			continue
+		}
+		tag.AddUnsynchronisedLyricsFrame(uslf)
+	}
 	tag.AddUnsynchronisedLyricsFrame(id3v2.UnsynchronisedLyricsFrame{
 		Encoding:          id3v2.EncodingUTF8,
 		Language:          "eng",


### PR DESCRIPTION
1. When embedLyric, if the language id and contentdiscriptor is the same with existing frames, the language id with become unrecognizable. I need to delete the old frame first.
2. Add a function to adjust lyric delay. I downloaded some lyrics and embed them with file, but the time is not synced with the music from youtube. This can adjust the delay, also save the result into mp3 file.