### PR TITLE
Fix a bug p.subtitle is not closed during initialization. 

### DIFF
--- a/playingbar.go
+++ b/playingbar.go
@@ -161,6 +161,7 @@ func (p *PlayingBar) newProgress(currentSong *AudioFile, full int) {
 	p.setSongTitle(currentSong.name)
 	p.hasTag = false
 	p.subtitles = nil
+	p.subtitle = nil
 	p.tag = nil
 
 	var tag *id3v2.Tag


### PR DESCRIPTION
solve a small bug: when a song has subtitle, and 2nd song doesn't have, 3rd song will show the subtitle of 1st song.