### PR TITLE
Better color support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Each panel has it's own additional keybinding. To view the available keybinding 
 | ?               |                     toggle help |
 | m               |                       open repl |
 | T               |                   switch lyrics |
+| c               |                     show colors |
 
 
 | Key (Playlist)  |                     Description |

--- a/colors.go
+++ b/colors.go
@@ -10,12 +10,15 @@ import (
 
 type Colors struct {
 	accent     tcell.Color
-	foreground tcell.Color
 	background tcell.Color
+	foreground tcell.Color
 	// title refers to now_playing_title in config file
-	title    tcell.Color
-	popup    tcell.Color
-	playlist tcell.Color
+	title       tcell.Color
+	popup       tcell.Color
+	playlistHi  tcell.Color
+	playlistDir tcell.Color
+	queueHi     tcell.Color
+	subtitle    string
 }
 
 func init() {
@@ -25,12 +28,15 @@ func init() {
 func newColor() *Colors {
 
 	defaultColors := map[string]string{
-		"Color.accent":            "darkcyan",
-		"Color.background":        "none",
-		"Color.foreground":        "white",
-		"Color.now_playing_title": "darkgreen",
-		"Color.playlist":          "white",
-		"Color.popup":             "black",
+		"Color.accent":             "darkcyan",
+		"Color.background":         "none",
+		"Color.foreground":         "white",
+		"Color.popup":              "black",
+		"Color.playlist_directory": "darkcyan",
+		"Color.playlist_highlight": "darkcyan",
+		"Color.queue_highlight":    "darkcyan",
+		"Color.now_playing_title":  "darkgreen",
+		"Color.subtitle":           "darkgoldenrod",
 	}
 
 	anko := gomu.anko
@@ -47,36 +53,28 @@ func newColor() *Colors {
 		}
 	}
 
-
 	accent := anko.GetString("Color.accent")
-	foreground := anko.GetString("Color.foreground")
 	background := anko.GetString("Color.background")
+	foreground := anko.GetString("Color.foreground")
 	popup := anko.GetString("Color.popup")
+	playlistDir := anko.GetString("Color.playlist_directory")
+	playlistHi := anko.GetString("Color.playlist_highlight")
+	queueHi := anko.GetString("Color.queue_highlight")
 	title := anko.GetString("Color.now_playing_title")
-	playlist := anko.GetString("Color.playlist")
+	subtitle := anko.GetString("Color.subtitle")
 
 	color := &Colors{
-		accent:     tcell.ColorNames[accent],
-		foreground: tcell.ColorNames[foreground],
-		background: tcell.ColorNames[background],
-		popup:      tcell.ColorNames[popup],
-		title:      tcell.ColorNames[title],
-		playlist:   tcell.ColorNames[playlist],
+		accent:      tcell.ColorNames[accent],
+		foreground:  tcell.ColorNames[foreground],
+		background:  tcell.ColorNames[background],
+		popup:       tcell.ColorNames[popup],
+		playlistDir: tcell.ColorNames[playlistDir],
+		playlistHi:  tcell.ColorNames[playlistHi],
+		queueHi:     tcell.ColorNames[queueHi],
+		title:       tcell.ColorNames[title],
+		subtitle:    subtitle,
 	}
 	return color
-}
-
-func isValidColor(x tcell.Color) bool {
-	return (x == tcell.ColorDefault) || x >= tcell.ColorBlack && x <= tcell.ColorYellowGreen
-}
-
-func intToColor(x int) tcell.Color {
-	
-	if x == -1 {
-		return tcell.ColorDefault
-	}
-
-	return tcell.Color(x) + tcell.ColorBlack
 }
 
 func colorsPopup() tview.Primitive {
@@ -99,7 +97,7 @@ func colorsPopup() tview.Primitive {
 		fmt.Fprintf(textView, "%20s [:%s]%s[:-] ", name, name, colorPad)
 
 		if i == 2 {
-			fmt.Fprint(textView, "\n")	
+			fmt.Fprint(textView, "\n")
 			i = 0
 			continue
 		}

--- a/colors.go
+++ b/colors.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
 )
 
 type Colors struct {
@@ -65,4 +68,34 @@ func newColor() *Colors {
 		playlist:   tcell.GetColor(playlist),
 	}
 	return color
+}
+
+func colorsPopup() tview.Primitive {
+
+	textView := tview.NewTextView().
+		SetWrap(true).
+		SetDynamicColors(true).
+		SetWrap(true).
+		SetWordWrap(true)
+
+	textView.
+		SetBorder(true).
+		SetTitle(" Colors ").
+		SetBorderPadding(1, 1, 2, 2)
+
+
+	for i := tcell.ColorBlack; i <= tcell.ColorYellowGreen; i++ {
+		fmt.Fprintf(textView, "%-3d [:#%06x]   [-:-] ", i - tcell.ColorBlack, i.Hex())
+	}
+
+	textView.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Key() {
+		case tcell.KeyEsc:
+			gomu.pages.RemovePage("show-color-popup")
+			gomu.popups.pop()
+		}
+		return event
+	})
+
+	return textView
 }

--- a/command.go
+++ b/command.go
@@ -445,6 +445,12 @@ func (c Command) defineCommands() {
 		}
 	})
 
+	c.define("show_colors", func() {
+		cp := colorsPopup()
+		gomu.pages.AddPage("show-color-popup", center(cp, 95, 40), true, true)
+		gomu.popups.push(cp)
+	})
+
 	for name, cmd := range c.commands {
 		err := gomu.anko.Define(name, cmd)
 		if err != nil {

--- a/gomu.go
+++ b/gomu.go
@@ -130,8 +130,8 @@ func (g *Gomu) setFocusPanel(panel Panel) {
 
 // Removes the color of the given panel
 func (g *Gomu) setUnfocusPanel(panel Panel) {
-	g.prevPanel.SetBorderColor(g.colors.background)
-	g.prevPanel.SetTitleColor(g.colors.background)
+	g.prevPanel.SetBorderColor(g.colors.foreground)
+	g.prevPanel.SetTitleColor(g.colors.foreground)
 }
 
 // Quit the application and do the neccessary clean up

--- a/playingbar.go
+++ b/playingbar.go
@@ -43,6 +43,7 @@ func newPlayingBar() *PlayingBar {
 
 	textView := tview.NewTextView().SetTextAlign(tview.AlignCenter)
 	textView.SetBackgroundColor(gomu.colors.background)
+	textView.SetDynamicColors(true)
 
 	frame := tview.NewFrame(textView).SetBorders(1, 1, 1, 1, 1, 1)
 	frame.SetBorder(true).SetTitle(" Now Playing ")
@@ -113,10 +114,11 @@ func (p *PlayingBar) run() error {
 		}
 
 		gomu.app.QueueUpdateDraw(func() {
-			p.text.SetText(fmt.Sprintf("%s ┃%s┫ %s\n\n%v",
+			p.text.SetText(fmt.Sprintf("%s ┃%s┫ %s\n\n[%s]%v[-]",
 				fmtDuration(start),
 				progressBar,
 				fmtDuration(end),
+				gomu.colors.subtitle,
 				lyricText,
 			))
 		})

--- a/playlist.go
+++ b/playlist.go
@@ -128,6 +128,7 @@ func newPlaylist(args Args) *Playlist {
 	}
 
 	root.SetReference(rootAudioFile)
+	root.SetColor(gomu.colors.playlist)
 
 	playlist.
 		SetTitle(playlist.defaultTitle).
@@ -418,9 +419,9 @@ func (p *Playlist) createPlaylist(name string) error {
 func (p *Playlist) setHighlight(currNode *tview.TreeNode) {
 
 	if p.prevNode != nil {
-		p.prevNode.SetColor(gomu.colors.background)
+		p.prevNode.SetColor(gomu.colors.foreground)
 	}
-	currNode.SetColor(gomu.colors.accent)
+	currNode.SetColor(gomu.colors.playlist)
 	p.SetCurrentNode(currNode)
 
 	if currNode.GetReference().(*AudioFile).isAudioFile {
@@ -718,7 +719,7 @@ func populate(root *tview.TreeNode, rootPath string) error {
 			displayText := setDisplayText(audioFile)
 
 			child.SetReference(audioFile)
-			child.SetColor(gomu.colors.accent)
+			child.SetColor(gomu.colors.playlist)
 			child.SetText(displayText)
 			root.AddChild(child)
 			populate(child, path)

--- a/playlist.go
+++ b/playlist.go
@@ -110,7 +110,7 @@ func newPlaylist(args Args) *Playlist {
 	}
 
 	root := tview.NewTreeNode(rootTextView).
-		SetColor(gomu.colors.accent)
+		SetColor(gomu.colors.playlistDir)
 
 	tree := tview.NewTreeView().SetRoot(root)
 	tree.SetBackgroundColor(gomu.colors.background)
@@ -128,7 +128,7 @@ func newPlaylist(args Args) *Playlist {
 	}
 
 	root.SetReference(rootAudioFile)
-	root.SetColor(gomu.colors.playlist)
+	root.SetColor(gomu.colors.playlistDir)
 
 	playlist.
 		SetTitle(playlist.defaultTitle).
@@ -419,15 +419,17 @@ func (p *Playlist) createPlaylist(name string) error {
 func (p *Playlist) setHighlight(currNode *tview.TreeNode) {
 
 	if p.prevNode != nil {
-		p.prevNode.SetColor(gomu.colors.foreground)
+		if p.prevNode.GetReference().(*AudioFile).isAudioFile {
+			p.prevNode.SetColor(gomu.colors.foreground)
+		} else {
+			p.prevNode.SetColor(gomu.colors.playlistDir)
+		}
 	}
-	currNode.SetColor(gomu.colors.playlist)
+
+	currNode.SetColor(gomu.colors.playlistHi)
 	p.SetCurrentNode(currNode)
 
-	if currNode.GetReference().(*AudioFile).isAudioFile {
-		p.prevNode = currNode
-	}
-
+	p.prevNode = currNode
 }
 
 // Traverses the playlist and finds the AudioFile struct
@@ -719,7 +721,7 @@ func populate(root *tview.TreeNode, rootPath string) error {
 			displayText := setDisplayText(audioFile)
 
 			child.SetReference(audioFile)
-			child.SetColor(gomu.colors.playlist)
+			child.SetColor(gomu.colors.playlistDir)
 			child.SetText(displayText)
 			root.AddChild(child)
 			populate(child, path)

--- a/popup.go
+++ b/popup.go
@@ -271,6 +271,7 @@ func helpPopup(panel Panel) {
 		"?      toggle help",
 		"m      open repl",
 		"T      switch lyrics",
+		"c      show colors",
 	}
 
 	list := tview.NewList().ShowSecondaryText(false)

--- a/queue.go
+++ b/queue.go
@@ -409,8 +409,8 @@ func newQueue() *Queue {
 
 	queue.
 		ShowSecondaryText(false).
-		SetSelectedBackgroundColor(gomu.colors.accent).
-		SetSelectedTextColor(tcell.ColorWhite).
+		SetSelectedBackgroundColor(gomu.colors.queueHi).
+		SetSelectedTextColor(gomu.colors.foreground).
 		SetHighlightFullLine(true)
 
 	queue.

--- a/queue.go
+++ b/queue.go
@@ -358,10 +358,7 @@ func (q *Queue) shuffle() {
 // Initiliaze new queue with default values
 func newQueue() *Queue {
 
-	list := tview.NewList().
-		ShowSecondaryText(false)
-
-	list.SetBackgroundColor(gomu.colors.background)
+	list := tview.NewList()
 
 	queue := &Queue{
 		List:           list,
@@ -409,12 +406,19 @@ func newQueue() *Queue {
 	})
 
 	queue.updateTitle()
-	queue.SetBorder(true).SetTitleAlign(tview.AlignLeft)
+
 	queue.
-		SetSelectedBackgroundColor(tcell.ColorDarkCyan).
+		ShowSecondaryText(false).
+		SetSelectedBackgroundColor(gomu.colors.accent).
 		SetSelectedTextColor(tcell.ColorWhite).
-		SetHighlightFullLine(true).
-		SetBorderPadding(0, 0, 1, 1)
+		SetHighlightFullLine(true)
+
+	queue.
+		SetBorder(true).
+		SetTitleAlign(tview.AlignLeft).
+		SetBorderPadding(0, 0, 1, 1).
+		SetBorderColor(gomu.colors.foreground).
+		SetBackgroundColor(gomu.colors.background)
 
 	return queue
 

--- a/start.go
+++ b/start.go
@@ -462,6 +462,7 @@ func start(application *tview.Application, args Args) {
 			'B': "rewind_fast",
 			'm': "repl",
 			'T': "switch_lyric",
+			'c': "show_colors",
 		}
 
 		for key, cmd := range cmds {

--- a/start.go
+++ b/start.go
@@ -227,9 +227,15 @@ module Color {
 	accent            = "darkcyan"
 	background        = "none"
 	foreground        = "white"
-	now_playing_title = "darkgreen"
-	playlist          = "white"
 	popup             = "black"
+
+	playlist_directory = "darkcyan"
+	playlist_highlight = "darkcyan"
+
+	queue_highlight    = "darkcyan"
+
+	now_playing_title = "darkgreen"
+	subtitle          = "darkgoldenrod"
 }
 
 # you can get the syntax highlighting for this language here:

--- a/start.go
+++ b/start.go
@@ -223,14 +223,13 @@ module Emoji {
 }
 
 module Color {
-	# not all colors can be reproducible in terminal
-	# changing hex colors may or may not produce expected result
-	accent            = "#008B8B"
+	# you may choose colors by pressing 'c'
+	accent            = "darkcyan"
 	background        = "none"
-	foreground        = "#FFFFFF"
-	now_playing_title = "#017702"
-	playlist          = "#008B8B"
-	popup             = "#0A0F14"
+	foreground        = "white"
+	now_playing_title = "darkgreen"
+	playlist          = "white"
+	popup             = "black"
 }
 
 # you can get the syntax highlighting for this language here:

--- a/test/config
+++ b/test/config
@@ -36,7 +36,8 @@ module Color {
 	background        = "none"
 	foreground        = "white"
 	now_playing_title = "darkgreen"
-	playlist          = "white"
+	# the color of the directory in playlist
+	playlist          = "darkslategray"
 	popup             = "black"
 }
 

--- a/test/config
+++ b/test/config
@@ -31,14 +31,13 @@ module Emoji {
 }
 
 module Color {
-	# not all colors can be reproducible in terminal
-	# changing hex colors may or may not produce expected result
-	accent            = "#008B8B"
+	# you may choose colors by pressing 'c'
+	accent            = "darkcyan"
 	background        = "none"
-	foreground        = "#FFFFFF"
-	now_playing_title = "#017702"
-	playlist          = "#008B8B"
-	popup             = "#0A0F14"
+	foreground        = "white"
+	now_playing_title = "darkgreen"
+	playlist          = "white"
+	popup             = "black"
 }
 
 func fib(x) {

--- a/test/config
+++ b/test/config
@@ -35,10 +35,15 @@ module Color {
 	accent            = "darkcyan"
 	background        = "none"
 	foreground        = "white"
-	now_playing_title = "darkgreen"
-	# the color of the directory in playlist
-	playlist          = "darkslategray"
 	popup             = "black"
+
+	playlist_directory = "darkcyan"
+	playlist_highlight = "darkcyan"
+
+	queue_highlight    = "darkcyan"
+
+	now_playing_title = "darkgreen"
+	subtitle          = "darkgoldenrod"
 }
 
 func fib(x) {

--- a/test/config
+++ b/test/config
@@ -114,6 +114,8 @@ Keybinds.def_q("i", func() {
 	})
 })
 
+Keybinds.def_g("c", show_colors)
+
 # you can get the syntax highlighting for this language here:
 # https://github.com/mattn/anko/tree/master/misc/vim
 # vim: ft=anko


### PR DESCRIPTION
Currently, our config file uses 6 digit hex value to represent color in the terminal. While this is convenient to add your own color but it doesn't mean it will produce the correct color. Having to try and error using different hex values each time will make it difficult to configure. By using `tcell.ColorNames` we can easily see available colors can be produced in the terminal with their respective name. This is much easier compared to use hex value.

Pressing `c` in gomu will show available colors:
![image](https://user-images.githubusercontent.com/50593529/111253718-a04e7700-864e-11eb-8289-60b839f3fa33.png)
 