### PR TITLE
Better config/new test for start.go

### DIFF
--- a/start.go
+++ b/start.go
@@ -33,14 +33,14 @@ type Panel interface {
 }
 
 // Default values for command line arguments.
-// TODO: change to $XDG_* variables
+// TODO: change to os.UserHomeDir() calls
 const (
 	configPath     = "~/.config/gomu/config"
 	cacheQueuePath = "~/.local/share/gomu/queue.cache"
 	musicPath      = "~/music" //by default this is uppercase
 )
 
-// Args is the augs for gomu executable
+// Args is the args for gomu executable
 type Args struct {
 	config  *string
 	empty   *bool

--- a/start.go
+++ b/start.go
@@ -33,10 +33,11 @@ type Panel interface {
 }
 
 // Default values for command line arguments.
+// TODO: change to $XDG_* variables
 const (
 	configPath     = "~/.config/gomu/config"
 	cacheQueuePath = "~/.local/share/gomu/queue.cache"
-	musicPath      = "~/music"
+	musicPath      = "~/music" //by default this is uppercase
 )
 
 // Args is the augs for gomu executable
@@ -48,14 +49,17 @@ type Args struct {
 }
 
 func getArgs() Args {
-	ar := Args{
-		config:  flag.String("config", configPath, "Specify config file"),
-		empty:   flag.Bool("empty", false, "Open gomu with empty queue. Does not override previous queue"),
-		music:   flag.String("music", musicPath, "Specify music directory"),
-		version: flag.Bool("version", false, "Print gomu version"),
-	}
+	configFlag := flag.String("config", configPath, "Specify config file")
+	emptyFlag := flag.Bool("empty", false, "Open gomu with empty queue. Does not override previous queue")
+	musicFlag := flag.String("music", musicPath, "Specify music directory")
+	versionFlag := flag.Bool("version", false, "Print gomu version")
 	flag.Parse()
-	return ar
+	return Args{
+		config:  configFlag,
+		empty:   emptyFlag,
+		music:   musicFlag,
+		version: versionFlag,
+	}
 }
 
 // built-in functions

--- a/start_test.go
+++ b/start_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/issadarkthing/gomu/anko"
@@ -10,6 +13,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Test default case
+func TestGetArgsDefaults(t *testing.T) {
+	args := getArgs()
+	assert.Equal(t, *args.config, "~/.config/gomu/config")
+	assert.Equal(t, *args.empty, false)
+	assert.Equal(t, *args.music, "~/music")
+	assert.Equal(t, *args.version, false)
+}
+
+// Test non-standard flags/the empty/version flags
 func TestGetArgs(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -21,12 +34,6 @@ func TestGetArgs(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
-	// Test default case
-	ar := getArgs()
-	assert.Equal(t, *ar.config, "~/.config/gomu/config")
-	assert.Equal(t, *ar.empty, false)
-	assert.Equal(t, *ar.music, "~/music")
-	assert.Equal(t, *ar.version, false)
 
 	// Test setting config flag
 	testConfig := filepath.Join(cfgDir, ".tmp", "gomu")
@@ -41,31 +48,45 @@ func TestGetArgs(t *testing.T) {
 		t.Error(err)
 		t.FailNow()
 	}
-	os.Args = []string{"cmd", "-config", tmpCfgf.Name()}
-	ar = getArgs()
-	assert.Equal(t, *ar.config, tmpCfgf.Name())
 
-	// Test -empty flag
-	os.Args = []string{"cmd", "-empty"}
-	ar = getArgs()
-	assert.Equal(t, *ar.empty, true)
-	assert.Zero(t, gomu.queue) // not sure if that's correct
-
-	// Test setting music flag
 	testMusic := filepath.Join(home, ".tmp", "gomu")
 	_, err = os.Stat(testMusic)
 	if os.IsNotExist(err) {
 		os.MkdirAll(testMusic, 0755)
 	}
 	defer os.RemoveAll(testMusic)
-	os.Args = []string{"cmd", "-music", testMusic}
-	ar = getArgs()
-	assert.Equal(t, *ar.music, testMusic)
 
-	// Test the usage of version flag
-	os.Args = []string{"cmd", "-version"}
-	ar = getArgs()
-	assert.Equal(t, *ar.version, true)
+	boolChecks := []struct {
+		name string
+		arg  bool
+		want bool
+	}{
+		{"empty", true, true},
+		{"version", true, true},
+	}
+	for _, check := range boolChecks {
+		t.Run("testing bool flag "+check.name, func(t *testing.T) {
+			flag.CommandLine.Set(check.name, strconv.FormatBool(check.arg))
+			flag.CommandLine.Parse(os.Args[1:])
+			assert.Equal(t, check.arg, check.want)
+		})
+	}
+	strChecks := []struct {
+		name string
+		arg  string
+		want string
+	}{
+		{"config", tmpCfgf.Name(), tmpCfgf.Name()},
+		{"music", testMusic, testMusic},
+	}
+	for _, check := range strChecks {
+		t.Run("testing string flag "+check.name, func(t *testing.T) {
+			flag.CommandLine.Set(check.name, check.arg)
+			flag.CommandLine.Parse(os.Args[1:])
+			fmt.Println("flag value: ", check.arg)
+			assert.Equal(t, check.arg, check.want)
+		})
+	}
 }
 
 func TestSetupHooks(t *testing.T) {

--- a/start_test.go
+++ b/start_test.go
@@ -1,12 +1,72 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/issadarkthing/gomu/anko"
 	"github.com/issadarkthing/gomu/hook"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestGetArgs(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	cfgDir, err := os.UserConfigDir()
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	// Test default case
+	ar := getArgs()
+	assert.Equal(t, *ar.config, "~/.config/gomu/config")
+	assert.Equal(t, *ar.empty, false)
+	assert.Equal(t, *ar.music, "~/music")
+	assert.Equal(t, *ar.version, false)
+
+	// Test setting config flag
+	testConfig := filepath.Join(cfgDir, ".tmp", "gomu")
+	_, err = os.Stat(testConfig)
+	if os.IsNotExist(err) {
+		os.MkdirAll(testConfig, 0755)
+	}
+	defer os.RemoveAll(testConfig)
+	//create a temporary config file
+	tmpCfgf, err := os.CreateTemp(testConfig, "config")
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+	os.Args = []string{"cmd", "-config", tmpCfgf.Name()}
+	ar = getArgs()
+	assert.Equal(t, *ar.config, tmpCfgf.Name())
+
+	// Test -empty flag
+	os.Args = []string{"cmd", "-empty"}
+	ar = getArgs()
+	assert.Equal(t, *ar.empty, true)
+	assert.Zero(t, gomu.queue) // not sure if that's correct
+
+	// Test setting music flag
+	testMusic := filepath.Join(home, ".tmp", "gomu")
+	_, err = os.Stat(testMusic)
+	if os.IsNotExist(err) {
+		os.MkdirAll(testMusic, 0755)
+	}
+	defer os.RemoveAll(testMusic)
+	os.Args = []string{"cmd", "-music", testMusic}
+	ar = getArgs()
+	assert.Equal(t, *ar.music, testMusic)
+
+	// Test the usage of version flag
+	os.Args = []string{"cmd", "-version"}
+	ar = getArgs()
+	assert.Equal(t, *ar.version, true)
+}
 
 func TestSetupHooks(t *testing.T) {
 


### PR DESCRIPTION
I'd like to modify the way config is set up. By default the config file is hardcoded in _start.go_ and the user has to copy it's contents instead of being able to launch the player instantly, which is not good. Also it should be more agnostic, for example by using `os.UserHomeDir` instead of `"~"`.

But first of all I think test coverage should be increased before doing any major changes and I think this PR might be a good starting point.